### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ngaremaina/Mapishi/security/code-scanning/1](https://github.com/Ngaremaina/Mapishi/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to build and test the code. This change ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
